### PR TITLE
change wording

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
           <p>
             RFC 5545, CalDAV, JMAP: each one has quirks, and real servers pile on more.
             Most libraries quietly get recurrences wrong or skip the hard parts entirely.
-            We put an effort into extending compatibity.
+            We put an effort into extending compatibility.
           </p>
           <p>
             Small team, real servers, no company behind it. Funded by <a href="https://nlnet.nl/NGI0" target="_blank" rel="noopener">NLnet NGI Zero</a>.


### PR DESCRIPTION
I am not sure about where it is used. Thunderbird uses the js variant, not our stuff. Nextcloud is based on PHP, so I think it should not be mentioned.