### PR TITLE
Add draft AI policy, copy-pasted from icalendar

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,6 +12,7 @@
           {% unless page.url == "/" %}<li><a href="/">Home</a></li>{% endunless %}
           {% unless page.url contains "/software" %}<li><a href="/software">Software</a></li>{% endunless %}
           {% unless page.url contains "/team" %}<li><a href="/team">Team</a></li>{% endunless %}
+          {% unless page.url contains "/ai-policy" %}<li><a href="/ai-policy">AI policy</a></li>{% endunless %}
         </ul>
       </div>
       <div class="footer-col">

--- a/ai-policy/index.html
+++ b/ai-policy/index.html
@@ -10,7 +10,7 @@ hero_sub: Our policy on the use of artificial intelligence (AI)
     <div class="prose">
 
       <p>We want to protect the joy, goodwill, and volunteer time of the maintainers and contributors of the Python Calendaring Ecosystem (PCE). As such, we take a strong stance against artificial intelligence (AI) abuse.</p>
-      <p>Contributors to PCE must follow this AI policy as described below.</p>
+      <p>Contributors to PCE must follow PCE's AI policy as described in this section and its subsections.</p>
 
       <h2 id="responsible-ai-use"><a href="#responsible-ai-use" class="section-anchor">Responsible AI use <span class="section-anchor-icon">🔗</span></a></h2>
       <p>You may responsibly use AI as a tool to draft a pull request. That means you must comply with pull request requirements as defined by each project and follow PCE's <a href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noopener">Code of Conduct</a>.</p>

--- a/ai-policy/index.html
+++ b/ai-policy/index.html
@@ -28,7 +28,7 @@ hero_sub: Our policy on the use of artificial intelligence (AI)
       </section>
       <section class="section" id="ai-abuse">
         <h3>AI abuse<a class="headerlink" href="#ai-abuse" title="Link to this heading">#</a></h3>
-        <p>You may not abuse AI to generate a pull request that is disruptive to the PCS community or does not adhere to <a class="reference internal" href="#responsible-ai-use"><span class="std std-ref">Responsible AI use</span></a> described in the previous subsection.
+        <p>You may not abuse AI to generate a pull request that is disruptive to the PCE community or does not adhere to <a class="reference internal" href="#responsible-ai-use"><span class="std std-ref">Responsible AI use</span></a> described in the previous subsection.
           Examples of such abuse and irresponsible use include the following actions.</p>
         <ul class="simple">
           <li>You claim no responsibility for the output of AI generated content.</li>
@@ -41,8 +41,8 @@ hero_sub: Our policy on the use of artificial intelligence (AI)
       <section class="section" id="report-suspected-violations">
         <h3>Report suspected violations<a class="headerlink" href="#report-suspected-violations" title="Link to this heading">#</a></h3>
         <p>To report a suspected violation of this AI policy, see the <a class="reference external" href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md#enforcement">Enforcement</a> section in the Code of Conduct.
-          The maintainers may close pull requests without providing feedback that they deem to be spam, AI slop, abuse, or that do not comply with <a class="reference internal" href="#pull-request-requirements"><span class="std std-ref">pull request requirements</span></a>.
-          The maintainers may also take further action, including suspend, ban, or report GitHub users, as described in PCS's <a class="reference external" href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>.</p>
+          The maintainers may close pull requests without providing feedback that they deem to be spam, AI slop, or abuse.
+          The maintainers may also take further action, including suspend, ban, or report GitHub users, as described in PCE's <a class="reference external" href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>.</p>
       </section>
 
     </div>

--- a/ai-policy/index.html
+++ b/ai-policy/index.html
@@ -2,48 +2,40 @@
 layout: page
 title: AI policy
 eyebrow: Python Calendaring Ecosystem
-hero_sub: Our policy on the use of artificial intelligence (AI)
+hero_sub: Our policy on the use of artificial intelligence
 ---
 
 <section class="section">
   <div class="container">
     <div class="prose">
 
-      <h2>Artificial intelligence policy<a class="headerlink" href="#artificial-intelligence-policy" title="Link to this heading">#</a></h2>
-      <p>We want to protect the joy, goodwill, and volunteer time of the maintainers and contributors of the Python Calendaring Ecosystem (PCE). As such, we take a strong stance against artificial intelligence (AI) abuse.</p>
-      <p>Contributors to PCE must follow PCE's AI policy as described in this section and its subsections.</p>
-      <section class="section" id="responsible-ai-use">
-        <h3>Responsible AI use<a class="headerlink" href="#responsible-ai-use" title="Link to this heading">#</a></h3>
-        <p>You may responsibly use AI as a tool to draft a pull request.
-          That means you must comply with pull request requirements as defined by each project and follow PCE's <a class="reference external" href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>.</p>
-        <p>If you use AI in your work:</p>
-        <ul>
-          <li>You must take responsibility for the output, including reviewing and validating the output for accuracy and ensuring it resolves an issue.</li>
-          <li>You must check the AI's terms of use, and ensure that outputs are not reconstructed from copyrighted sources.</li>
-          <li>You are expected to understand and be able to explain design and code decisions.</li>
-          <li>In your git commit messages, you must specify both (1) which AI model and version you used, and (2) how you used it, by either including the prompts and interactions you used or summarizing them.</li>
-          <li>You must disclose that you used AI in your change log entry.</li>
-          <li>You shall be held accountable for your AI-generated content.</li>
-        </ul>
-      </section>
-      <section class="section" id="ai-abuse">
-        <h3>AI abuse<a class="headerlink" href="#ai-abuse" title="Link to this heading">#</a></h3>
-        <p>You may not abuse AI to generate a pull request that is disruptive to the PCE community or does not adhere to <a class="reference internal" href="#responsible-ai-use"><span class="std std-ref">Responsible AI use</span></a> described in the previous subsection.
-          Examples of such abuse and irresponsible use include the following actions.</p>
-        <ul class="simple">
-          <li>You claim no responsibility for the output of AI generated content.</li>
-          <li>Your pull request demonstrates no understanding or thought whatsoever to solve an issue.</li>
-          <li>Your pull request plagiarizes copyrighted or other material to which you have no legal claim.</li>
-          <li>You ignore or don't respond to feedback.</li>
-          <li>The GitHub account is itself an AI agent.</li>
-        </ul>
-      </section>
-      <section class="section" id="report-suspected-violations">
-        <h3>Report suspected violations<a class="headerlink" href="#report-suspected-violations" title="Link to this heading">#</a></h3>
-        <p>To report a suspected violation of this AI policy, see the <a class="reference external" href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md#enforcement">Enforcement</a> section in the Code of Conduct.
-          The maintainers may close pull requests without providing feedback that they deem to be spam, AI slop, or abuse.
-          The maintainers may also take further action, including suspend, ban, or report GitHub users, as described in PCE's <a class="reference external" href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>.</p>
-      </section>
+      <p>We want to protect the joy, goodwill, and volunteer time of the maintainers and contributors of the Python Calendaring Ecosystem (PCE). As such, we take a strong stance against AI abuse.</p>
+      <p>Contributors to PCE must follow this AI policy as described below.</p>
+
+      <h2 id="responsible-ai-use"><a href="#responsible-ai-use" class="section-anchor">Responsible AI use <span class="section-anchor-icon">🔗</span></a></h2>
+      <p>You may responsibly use AI as a tool to draft a pull request. That means you must comply with pull request requirements as defined by each project and follow PCE's <a href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noopener">Code of Conduct</a>.</p>
+      <p>If you use AI in your work:</p>
+      <ul>
+        <li>You must take responsibility for the output, including reviewing and validating it for accuracy and ensuring it resolves an issue.</li>
+        <li>You must check the AI's terms of use and ensure that outputs are not reconstructed from copyrighted sources.</li>
+        <li>You are expected to understand and be able to explain design and code decisions.</li>
+        <li>In your git commit messages, you must specify both (1) which AI model and version you used, and (2) how you used it, by either including the prompts and interactions or summarizing them.</li>
+        <li>You must disclose that you used AI in your change log entry.</li>
+        <li>You are accountable for your AI-generated content.</li>
+      </ul>
+
+      <h2 id="ai-abuse"><a href="#ai-abuse" class="section-anchor">AI abuse <span class="section-anchor-icon">🔗</span></a></h2>
+      <p>You may not abuse AI to generate a pull request that is disruptive to the PCE community or does not adhere to <a href="#responsible-ai-use">responsible AI use</a>. Examples of abuse include:</p>
+      <ul>
+        <li>Claiming no responsibility for the output of AI-generated content.</li>
+        <li>Submitting a pull request that demonstrates no understanding or thought toward solving the issue.</li>
+        <li>Plagiarising copyrighted or other material to which you have no legal claim.</li>
+        <li>Ignoring or failing to respond to feedback.</li>
+        <li>The GitHub account itself being an AI agent.</li>
+      </ul>
+
+      <h2 id="report-violations"><a href="#report-violations" class="section-anchor">Report suspected violations <span class="section-anchor-icon">🔗</span></a></h2>
+      <p>To report a suspected violation, see the <a href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md#enforcement" target="_blank" rel="noopener">Enforcement</a> section in the Code of Conduct. Maintainers may close pull requests without feedback if they are deemed spam, AI slop, or abuse. Maintainers may also suspend, ban, or report GitHub users, as described in PCE's <a href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noopener">Code of Conduct</a>.</p>
 
     </div>
   </div>

--- a/ai-policy/index.html
+++ b/ai-policy/index.html
@@ -1,0 +1,50 @@
+---
+layout: page
+title: AI policy
+eyebrow: Python Calendaring Ecosystem
+hero_sub: Our policy on the use of artificial intelligence (AI)
+---
+
+<section class="section">
+  <div class="container">
+    <div class="prose">
+
+      <h2>Artificial intelligence policy<a class="headerlink" href="#artificial-intelligence-policy" title="Link to this heading">#</a></h2>
+      <p>We want to protect the joy, goodwill, and volunteer time of the maintainers and contributors of the Python Calendaring Ecosystem (PCE). As such, we take a strong stance against artificial intelligence (AI) abuse.</p>
+      <p>Contributors to PCE must follow PCE's AI policy as described in this section and its subsections.</p>
+      <section class="section" id="responsible-ai-use">
+        <h3>Responsible AI use<a class="headerlink" href="#responsible-ai-use" title="Link to this heading">#</a></h3>
+        <p>You may responsibly use AI as a tool to draft a pull request.
+          That means you must comply with pull request requirements as defined by each project and follow PCE's <a class="reference external" href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>.</p>
+        <p>If you use AI in your work:</p>
+        <ul>
+          <li>You must take responsibility for the output, including reviewing and validating the output for accuracy and ensuring it resolves an issue.</li>
+          <li>You must check the AI's terms of use, and ensure that outputs are not reconstructed from copyrighted sources.</li>
+          <li>You are expected to understand and be able to explain design and code decisions.</li>
+          <li>In your git commit messages, you must specify both (1) which AI model and version you used, and (2) how you used it, by either including the prompts and interactions you used or summarizing them.</li>
+          <li>You must disclose that you used AI in your change log entry.</li>
+          <li>You shall be held accountable for your AI-generated content.</li>
+        </ul>
+      </section>
+      <section class="section" id="ai-abuse">
+        <h3>AI abuse<a class="headerlink" href="#ai-abuse" title="Link to this heading">#</a></h3>
+        <p>You may not abuse AI to generate a pull request that is disruptive to the PCS community or does not adhere to <a class="reference internal" href="#responsible-ai-use"><span class="std std-ref">Responsible AI use</span></a> described in the previous subsection.
+          Examples of such abuse and irresponsible use include the following actions.</p>
+        <ul class="simple">
+          <li>You claim no responsibility for the output of AI generated content.</li>
+          <li>Your pull request demonstrates no understanding or thought whatsoever to solve an issue.</li>
+          <li>Your pull request plagiarizes copyrighted or other material to which you have no legal claim.</li>
+          <li>You ignore or don't respond to feedback.</li>
+          <li>The GitHub account is itself an AI agent.</li>
+        </ul>
+      </section>
+      <section class="section" id="report-suspected-violations">
+        <h3>Report suspected violations<a class="headerlink" href="#report-suspected-violations" title="Link to this heading">#</a></h3>
+        <p>To report a suspected violation of this AI policy, see the <a class="reference external" href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md#enforcement">Enforcement</a> section in the Code of Conduct.
+          The maintainers may close pull requests without providing feedback that they deem to be spam, AI slop, abuse, or that do not comply with <a class="reference internal" href="#pull-request-requirements"><span class="std std-ref">pull request requirements</span></a>.
+          The maintainers may also take further action, including suspend, ban, or report GitHub users, as described in PCS's <a class="reference external" href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>.</p>
+      </section>
+
+    </div>
+  </div>
+</section>

--- a/ai-policy/index.html
+++ b/ai-policy/index.html
@@ -2,40 +2,43 @@
 layout: page
 title: AI policy
 eyebrow: Python Calendaring Ecosystem
-hero_sub: Our policy on the use of artificial intelligence
+hero_sub: Our policy on the use of artificial intelligence (AI)
 ---
 
 <section class="section">
   <div class="container">
     <div class="prose">
 
-      <p>We want to protect the joy, goodwill, and volunteer time of the maintainers and contributors of the Python Calendaring Ecosystem (PCE). As such, we take a strong stance against AI abuse.</p>
+      <p>We want to protect the joy, goodwill, and volunteer time of the maintainers and contributors of the Python Calendaring Ecosystem (PCE). As such, we take a strong stance against artificial intelligence (AI) abuse.</p>
       <p>Contributors to PCE must follow this AI policy as described below.</p>
 
       <h2 id="responsible-ai-use"><a href="#responsible-ai-use" class="section-anchor">Responsible AI use <span class="section-anchor-icon">🔗</span></a></h2>
       <p>You may responsibly use AI as a tool to draft a pull request. That means you must comply with pull request requirements as defined by each project and follow PCE's <a href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noopener">Code of Conduct</a>.</p>
       <p>If you use AI in your work:</p>
       <ul>
-        <li>You must take responsibility for the output, including reviewing and validating it for accuracy and ensuring it resolves an issue.</li>
-        <li>You must check the AI's terms of use and ensure that outputs are not reconstructed from copyrighted sources.</li>
+        <li>You must take responsibility for the output, including reviewing and validating the output for accuracy and ensuring it resolves an issue.</li>
+        <li>You must check the AI's terms of use, and ensure that outputs are not reconstructed from copyrighted sources.</li>
         <li>You are expected to understand and be able to explain design and code decisions.</li>
-        <li>In your git commit messages, you must specify both (1) which AI model and version you used, and (2) how you used it, by either including the prompts and interactions or summarizing them.</li>
+        <li>In your git commit messages, you must specify both (1) which AI model and version you used, and (2) how you used it, by either including the prompts and interactions you used or summarizing them.</li>
         <li>You must disclose that you used AI in your change log entry.</li>
-        <li>You are accountable for your AI-generated content.</li>
+        <li>You shall be held accountable for your AI-generated content.</li>
       </ul>
 
       <h2 id="ai-abuse"><a href="#ai-abuse" class="section-anchor">AI abuse <span class="section-anchor-icon">🔗</span></a></h2>
-      <p>You may not abuse AI to generate a pull request that is disruptive to the PCE community or does not adhere to <a href="#responsible-ai-use">responsible AI use</a>. Examples of abuse include:</p>
+      <p>You may not abuse AI to generate a pull request that is disruptive to the PCE community or does not adhere to <a href="#responsible-ai-use">responsible AI use</a> described in the previous section.
+        Examples of such abuse and irresponsible use include the following actions.</p>
       <ul>
-        <li>Claiming no responsibility for the output of AI-generated content.</li>
-        <li>Submitting a pull request that demonstrates no understanding or thought toward solving the issue.</li>
-        <li>Plagiarising copyrighted or other material to which you have no legal claim.</li>
-        <li>Ignoring or failing to respond to feedback.</li>
-        <li>The GitHub account itself being an AI agent.</li>
+        <li>You claim no responsibility for the output of AI generated content.</li>
+        <li>Your pull request demonstrates no understanding or thought whatsoever to solve an issue.</li>
+        <li>Your pull request plagiarizes copyrighted or other material to which you have no legal claim.</li>
+        <li>You ignore or don't respond to feedback.</li>
+        <li>The GitHub account is itself an AI agent.</li>
       </ul>
 
       <h2 id="report-violations"><a href="#report-violations" class="section-anchor">Report suspected violations <span class="section-anchor-icon">🔗</span></a></h2>
-      <p>To report a suspected violation, see the <a href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md#enforcement" target="_blank" rel="noopener">Enforcement</a> section in the Code of Conduct. Maintainers may close pull requests without feedback if they are deemed spam, AI slop, or abuse. Maintainers may also suspend, ban, or report GitHub users, as described in PCE's <a href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noopener">Code of Conduct</a>.</p>
+      <p>To report a suspected violation of this AI policy, see the <a href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md#enforcement" target="_blank" rel="noopener">Enforcement</a> section in the Code of Conduct.
+        The maintainers may close pull requests without providing feedback that they deem to be spam, AI slop, or abuse.
+        The maintainers may also take further action, including suspend, ban, or report GitHub users, as described in PCE's <a href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noopener">Code of Conduct</a>.</p>
 
     </div>
   </div>


### PR DESCRIPTION
- Note that we don't have a PyCal CoC yet, so it links to icalendar's.
- I'm not sure how this will look

Closes #24