### PR TITLE
UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pycal.org
 
-Source for [pycal.org](https://pycal.org) — the Python Web Calendaring Ecosystem website. Built with [Jekyll](https://jekyllrb.com/).
+Source for [pycal.org](https://pycal.org) — the Python Calendaring Ecosystem website. Built with [Jekyll](https://jekyllrb.com/).
 
 ## Prerequisites
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: Python Web Calendaring Ecosystem
+title: Python Calendaring Ecosystem
 description: Open source Python software for working with calendar data.
 url: https://pycal.org
 baseurl: ""

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,7 +9,6 @@
         <h4>Project</h4>
         <ul>
           {% unless page.url contains "/about" %}<li><a href="/about">About</a></li>{% endunless %}
-          {% unless page.url == "/" %}<li><a href="/">Home</a></li>{% endunless %}
           {% unless page.url contains "/software" %}<li><a href="/software">Software</a></li>{% endunless %}
           {% unless page.url contains "/team" %}<li><a href="/team">Team</a></li>{% endunless %}
           {% unless page.url contains "/ai-policy" %}<li><a href="/ai-policy">AI policy</a></li>{% endunless %}
@@ -27,7 +26,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <p>Python Web Calendaring Ecosystem.</p>
+      <p>{{ site.title }}.</p>
     </div>
   </div>
 </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,6 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{% if page.title %}{{ page.title }} — {% endif %}Python Web Calendaring Ecosystem</title>
+<title>{% if page.title %}{{ page.title }} — {% endif %}{{ site.title }}</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link

--- a/_includes/heading.html
+++ b/_includes/heading.html
@@ -1,0 +1,4 @@
+{%- assign level = include.level | default: 2 -%}
+{%- assign id = include.id | default: include.title | slugify -%}
+{%- assign class = include.class -%}
+<h{{ level }} id="{{ id }}"{% if class %} class="{{ class }}"{% endif %}><a href="#{{ id }}" class="heading-anchor">#</a>{{ include.title }}</h{{ level }}>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,18 +15,7 @@
 
   <button class="back-to-top" aria-label="Back to top" hidden>↑</button>
 
-  <script>
-    if (history.scrollRestoration) history.scrollRestoration = "manual";
-    window.scrollTo(0, 0);
-
-    const backToTop = document.querySelector(".back-to-top");
-    window.addEventListener("scroll", () => {
-      backToTop.hidden = window.scrollY < 400;
-    });
-    backToTop.addEventListener("click", () => {
-      window.scrollTo({ top: 0, behavior: "smooth" });
-    });
-  </script>
+  <script src="/assets/js/main.js" defer></script>
 </body>
 
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,20 @@
 
   {% include footer.html %}
 
-  <script>if (history.scrollRestoration) history.scrollRestoration = "manual"; window.scrollTo(0, 0);</script>
+  <button class="back-to-top" aria-label="Back to top" hidden>↑</button>
+
+  <script>
+    if (history.scrollRestoration) history.scrollRestoration = "manual";
+    window.scrollTo(0, 0);
+
+    const backToTop = document.querySelector(".back-to-top");
+    window.addEventListener("scroll", () => {
+      backToTop.hidden = window.scrollY < 400;
+    });
+    backToTop.addEventListener("click", () => {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    });
+  </script>
 </body>
 
 </html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,7 +4,7 @@ layout: default
 
 <header class="header--slim">
   <div class="container">
-    {% if page.eyebrow %}<p class="eyebrow">{{ page.eyebrow }}</p>{% endif %}
+    <p class="eyebrow">{{ page.eyebrow | default: site.title }}</p>
     <h1>{{ page.title }}</h1>
     {% if page.hero_sub %}<p class="hero-sub">{{ page.hero_sub }}</p>{% endif %}
   </div>

--- a/about/index.html
+++ b/about/index.html
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: About
-eyebrow: Python Calendaring Ecosystem
 hero_sub: The boring yet important stuff.
 ---
 
@@ -9,7 +8,7 @@ hero_sub: The boring yet important stuff.
   <div class="container">
     <div class="prose">
 
-      <h2>What this is</h2>
+      <h2 id="what-this-is"><a href="#what-this-is" class="heading-anchor">#</a>What this is</h2>
       <p>
         The Python Calendaring Ecosystem (PCE) is a collection of open source software written in Python covering the calendaring stack from top to bottom.
         PCE parses iCalendar files, computes recurrences, talks to CalDAV and JMAP servers, has CLI tools, and is integrated with Django.
@@ -17,7 +16,7 @@ hero_sub: The boring yet important stuff.
         The maintainers and contributors use parts of the PCE in real projects.
       </p>
 
-      <h2>Why it exists</h2>
+      <h2 id="why-it-exists"><a href="#why-it-exists" class="heading-anchor">#</a>Why it exists</h2>
       <p>
         Calendaring specifications are sometimes ambiguous, have omissions, and every server interprets them differently.
         Most Python libraries in this space don't handle recurrences according to the specifications, in ways that only show up in production, or just silently omit the hard parts.
@@ -26,14 +25,14 @@ hero_sub: The boring yet important stuff.
         We test against real servers, track compatibility per server, and fix what breaks.
       </p>
 
-      <h2>Standards we implement</h2>
+      <h2 id="standards"><a href="#standards" class="heading-anchor">#</a>Standards we implement</h2>
       <ul class="spec-list">
         {% for std in site.data.standards %}
         <li>{{ std.id }} — {{ std.name }}</li>
         {% endfor %}
       </ul>
 
-      <h2>Funding</h2>
+      <h2 id="funding"><a href="#funding" class="heading-anchor">#</a>Funding</h2>
       <p>
         Work for the PCE is funded by a generous grant from <a href="https://nlnet.nl" target="_blank" rel="noopener">NLnet</a> via the
         <a href="https://nlnet.nl/NGI0" target="_blank" rel="noopener">NGI Zero program</a>,
@@ -51,7 +50,7 @@ hero_sub: The boring yet important stuff.
         You can support the work for the Python Calendaring Ecosystem through <a href="https://opencollective.com/python-icalendar" target="_blank" rel="noopener">financial contribution</a>.
       </p>
 
-      <h2>License and governance</h2>
+      <h2 id="license-and-governance"><a href="#license-and-governance" class="heading-anchor">#</a>License and governance</h2>
       <p>
         All packages are free and open source software. Licenses vary by package, including BSD, LGPL, GPL, AGPL, and Apache 2.0.
         There is no foundation, nor formal structure.

--- a/about/index.html
+++ b/about/index.html
@@ -8,7 +8,7 @@ hero_sub: The boring yet important stuff.
   <div class="container">
     <div class="prose">
 
-      <h2 id="what-this-is"><a href="#what-this-is" class="heading-anchor">#</a>What this is</h2>
+      {% include heading.html title="What this is" %}
       <p>
         The Python Calendaring Ecosystem (PCE) is a collection of open source software written in Python covering the calendaring stack from top to bottom.
         PCE parses iCalendar files, computes recurrences, talks to CalDAV and JMAP servers, has CLI tools, and is integrated with Django.
@@ -16,7 +16,7 @@ hero_sub: The boring yet important stuff.
         The maintainers and contributors use parts of the PCE in real projects.
       </p>
 
-      <h2 id="why-it-exists"><a href="#why-it-exists" class="heading-anchor">#</a>Why it exists</h2>
+      {% include heading.html title="Why it exists" %}
       <p>
         Calendaring specifications are sometimes ambiguous, have omissions, and every server interprets them differently.
         Most Python libraries in this space don't handle recurrences according to the specifications, in ways that only show up in production, or just silently omit the hard parts.
@@ -25,14 +25,14 @@ hero_sub: The boring yet important stuff.
         We test against real servers, track compatibility per server, and fix what breaks.
       </p>
 
-      <h2 id="standards"><a href="#standards" class="heading-anchor">#</a>Standards we implement</h2>
+      {% include heading.html title="Standards we implement" id="standards" %}
       <ul class="spec-list">
         {% for std in site.data.standards %}
         <li>{{ std.id }} — {{ std.name }}</li>
         {% endfor %}
       </ul>
 
-      <h2 id="funding"><a href="#funding" class="heading-anchor">#</a>Funding</h2>
+      {% include heading.html title="Funding" %}
       <p>
         Work for the PCE is funded by a generous grant from <a href="https://nlnet.nl" target="_blank" rel="noopener">NLnet</a> via the
         <a href="https://nlnet.nl/NGI0" target="_blank" rel="noopener">NGI Zero program</a>,
@@ -50,7 +50,7 @@ hero_sub: The boring yet important stuff.
         You can support the work for the Python Calendaring Ecosystem through <a href="https://opencollective.com/python-icalendar" target="_blank" rel="noopener">financial contribution</a>.
       </p>
 
-      <h2 id="license-and-governance"><a href="#license-and-governance" class="heading-anchor">#</a>License and governance</h2>
+      {% include heading.html title="License and governance" %}
       <p>
         All packages are free and open source software. Licenses vary by package, including BSD, LGPL, GPL, AGPL, and Apache 2.0.
         There is no foundation, nor formal structure.

--- a/ai-policy/index.html
+++ b/ai-policy/index.html
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: AI policy
-eyebrow: Python Calendaring Ecosystem
 hero_sub: Our policy on the use of artificial intelligence (AI)
 ---
 
@@ -12,8 +11,8 @@ hero_sub: Our policy on the use of artificial intelligence (AI)
       <p>We want to protect the joy, goodwill, and volunteer time of the maintainers and contributors of the Python Calendaring Ecosystem (PCE). As such, we take a strong stance against artificial intelligence (AI) abuse.</p>
       <p>Contributors to PCE must follow PCE's AI policy as described in this section and its subsections.</p>
 
-      <h2 id="responsible-ai-use"><a href="#responsible-ai-use" class="section-anchor">Responsible AI use <span class="section-anchor-icon">🔗</span></a></h2>
-      <p>You may responsibly use AI as a tool to draft a pull request. That means you must comply with pull request requirements as defined by each project and follow PCE's <a href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noopener">Code of Conduct</a>.</p>
+      <h2 id="responsible-ai-use"><a href="#responsible-ai-use" class="heading-anchor">#</a>Responsible AI use</h2>
+      <p>You may responsibly use AI as a tool to draft a pull request. That means you must comply with pull request requirements as defined by each project and follow PCE's <a href="/code-of-conduct">Code of Conduct</a>.</p>
       <p>If you use AI in your work:</p>
       <ul>
         <li>You must take responsibility for the output, including reviewing and validating the output for accuracy and ensuring it resolves an issue.</li>
@@ -24,7 +23,7 @@ hero_sub: Our policy on the use of artificial intelligence (AI)
         <li>You shall be held accountable for your AI-generated content.</li>
       </ul>
 
-      <h2 id="ai-abuse"><a href="#ai-abuse" class="section-anchor">AI abuse <span class="section-anchor-icon">🔗</span></a></h2>
+      <h2 id="ai-abuse"><a href="#ai-abuse" class="heading-anchor">#</a>AI abuse</h2>
       <p>You may not abuse AI to generate a pull request that is disruptive to the PCE community or does not adhere to <a href="#responsible-ai-use">responsible AI use</a> described in the previous section.
         Examples of such abuse and irresponsible use include the following actions.</p>
       <ul>
@@ -35,10 +34,10 @@ hero_sub: Our policy on the use of artificial intelligence (AI)
         <li>The GitHub account is itself an AI agent.</li>
       </ul>
 
-      <h2 id="report-violations"><a href="#report-violations" class="section-anchor">Report suspected violations <span class="section-anchor-icon">🔗</span></a></h2>
-      <p>To report a suspected violation of this AI policy, see the <a href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md#enforcement" target="_blank" rel="noopener">Enforcement</a> section in the Code of Conduct.
+      <h2 id="report-violations"><a href="#report-violations" class="heading-anchor">#</a>Report suspected violations</h2>
+      <p>To report a suspected violation of this AI policy, see the <a href="/code-of-conduct#reporting-an-issue">Reporting an Issue</a> section in the Code of Conduct.
         The maintainers may close pull requests without providing feedback that they deem to be spam, AI slop, or abuse.
-        The maintainers may also take further action, including suspend, ban, or report GitHub users, as described in PCE's <a href="https://github.com/collective/icalendar/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noopener">Code of Conduct</a>.</p>
+        The maintainers may also take further action, including suspend, ban, or report GitHub users, as described in PCE's <a href="/code-of-conduct">Code of Conduct</a>.</p>
 
     </div>
   </div>

--- a/ai-policy/index.html
+++ b/ai-policy/index.html
@@ -11,7 +11,7 @@ hero_sub: Our policy on the use of artificial intelligence (AI)
       <p>We want to protect the joy, goodwill, and volunteer time of the maintainers and contributors of the Python Calendaring Ecosystem (PCE). As such, we take a strong stance against artificial intelligence (AI) abuse.</p>
       <p>Contributors to PCE must follow PCE's AI policy as described in this section and its subsections.</p>
 
-      <h2 id="responsible-ai-use"><a href="#responsible-ai-use" class="heading-anchor">#</a>Responsible AI use</h2>
+      {% include heading.html title="Responsible AI use" %}
       <p>You may responsibly use AI as a tool to draft a pull request. That means you must comply with pull request requirements as defined by each project and follow PCE's <a href="/code-of-conduct">Code of Conduct</a>.</p>
       <p>If you use AI in your work:</p>
       <ul>
@@ -23,7 +23,7 @@ hero_sub: Our policy on the use of artificial intelligence (AI)
         <li>You shall be held accountable for your AI-generated content.</li>
       </ul>
 
-      <h2 id="ai-abuse"><a href="#ai-abuse" class="heading-anchor">#</a>AI abuse</h2>
+      {% include heading.html title="AI abuse" %}
       <p>You may not abuse AI to generate a pull request that is disruptive to the PCE community or does not adhere to <a href="#responsible-ai-use">responsible AI use</a> described in the previous section.
         Examples of such abuse and irresponsible use include the following actions.</p>
       <ul>
@@ -34,7 +34,7 @@ hero_sub: Our policy on the use of artificial intelligence (AI)
         <li>The GitHub account is itself an AI agent.</li>
       </ul>
 
-      <h2 id="report-violations"><a href="#report-violations" class="heading-anchor">#</a>Report suspected violations</h2>
+      {% include heading.html title="Report suspected violations" id="report-violations" %}
       <p>To report a suspected violation of this AI policy, see the <a href="/code-of-conduct#reporting-an-issue">Reporting an Issue</a> section in the Code of Conduct.
         The maintainers may close pull requests without providing feedback that they deem to be spam, AI slop, or abuse.
         The maintainers may also take further action, including suspend, ban, or report GitHub users, as described in PCE's <a href="/code-of-conduct">Code of Conduct</a>.</p>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -17,8 +17,8 @@
   --stone-800: #292724;
   --stone-900: #1a1917;
   --ink: #111110;
-  --accent: #1a56db;
-  --accent-hover: #1447c0;
+  --accent: #0f766e;
+  --accent-hover: #0b5952;
   --dev-accent: #6d28d9;
   --font-serif: 'Playfair Display', Georgia, 'Times New Roman', serif;
   --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
@@ -34,6 +34,32 @@ html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   scroll-behavior: smooth;
+}
+
+:target,
+h1[id],
+h2[id],
+h3[id],
+h4[id] {
+  scroll-margin-top: 5rem;
+}
+
+:focus-visible {
+  outline: 2px solid var(--stone-900);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+::selection {
+  background: var(--stone-900);
+  color: var(--stone-50);
+}
+
+.prose a[target="_blank"]::after,
+.overview-prose a[target="_blank"]::after {
+  content: " ↗";
+  font-size: 0.85em;
+  opacity: 0.7;
 }
 
 /* Custom scrollbar — Webkit */
@@ -274,8 +300,6 @@ main {
 
 .section-alt {
   background: var(--stone-50);
-  border-top: 1px solid var(--stone-200);
-  border-bottom: 1px solid var(--stone-200);
 }
 
 .section-title {
@@ -288,31 +312,19 @@ main {
   scroll-margin-top: 80px;
 }
 
-.section-anchor {
-  color: inherit;
+.heading-anchor,
+.prose .heading-anchor {
+  color: var(--stone-400);
   text-decoration: none;
+  margin-right: 0.4em;
+  font-weight: 400;
+  transition: color 0.15s;
 }
 
-.section-anchor:hover {
+.heading-anchor:hover,
+.prose .heading-anchor:hover {
+  color: var(--stone-600);
   text-decoration: none;
-  color: inherit;
-}
-
-.section-anchor:hover .section-anchor-icon {
-  opacity: 1;
-}
-
-.section-anchor-icon {
-  width: 0.9em;
-  height: 0.9em;
-  margin-left: 0.4em;
-  vertical-align: middle;
-  opacity: 0;
-  transition: opacity 0.15s;
-}
-
-.section-title:hover .section-anchor-icon {
-  opacity: 1;
 }
 
 .section-desc {
@@ -362,12 +374,14 @@ main {
   background: var(--white);
   text-decoration: none;
   color: inherit;
-  transition: background 0.12s;
+  transition: background 0.15s, transform 0.15s, box-shadow 0.15s;
 }
 
 .package:hover {
   background: var(--stone-50);
   text-decoration: none;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 0.06);
 }
 
 .package--dev {
@@ -552,10 +566,20 @@ code {
   margin-bottom: 0;
 }
 
-.prose a {
-  color: var(--accent);
+.prose a,
+.overview-prose a,
+.see-all a {
+  color: var(--stone-900);
   text-decoration: underline;
   text-underline-offset: 2px;
+  text-decoration-color: var(--stone-400);
+  transition: text-decoration-color 0.15s;
+}
+
+.prose a:hover,
+.overview-prose a:hover,
+.see-all a:hover {
+  text-decoration-color: var(--stone-900);
 }
 
 .spec-list {
@@ -653,7 +677,7 @@ code {
 
 .member-github:hover,
 .member-linkedin:hover {
-  color: var(--accent);
+  color: var(--stone-900);
   text-decoration: none;
 }
 
@@ -661,6 +685,18 @@ code {
   font-size: 0.9rem;
   color: var(--stone-600);
   line-height: 1.75;
+}
+
+.member-bio a {
+  color: var(--stone-900);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: var(--stone-400);
+  transition: text-decoration-color 0.15s;
+}
+
+.member-bio a:hover {
+  text-decoration-color: var(--stone-900);
 }
 
 .member-packages {
@@ -876,4 +912,28 @@ footer {
   .nav-toggle:checked+.nav-toggle-label span:nth-child(3) {
     transform: translateY(-7px) rotate(-45deg);
   }
+}
+
+.back-to-top {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 1px solid var(--stone-300);
+  background: var(--stone-50);
+  color: var(--stone-600);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 0.08);
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  z-index: 100;
+}
+
+.back-to-top:hover {
+  background: var(--stone-100);
+  color: var(--stone-900);
+  border-color: var(--stone-400);
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -19,6 +19,8 @@
   --ink: #111110;
   --accent: #0f766e;
   --accent-hover: #0b5952;
+  --border: var(--stone-200);
+  --border-strong: var(--stone-400);
   --dev-accent: #6d28d9;
   --font-serif: 'Playfair Display', Georgia, 'Times New Roman', serif;
   --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
@@ -921,7 +923,7 @@ footer {
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 50%;
-  border: 1px solid var(--stone-300);
+  border: 1px solid var(--border);
   background: var(--stone-50);
   color: var(--stone-600);
   font-size: 1.1rem;
@@ -935,5 +937,5 @@ footer {
 .back-to-top:hover {
   background: var(--stone-100);
   color: var(--stone-900);
-  border-color: var(--stone-400);
+  border-color: var(--border-strong);
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,10 @@
+if (history.scrollRestoration) history.scrollRestoration = "manual";
+window.scrollTo(0, 0);
+
+const backToTop = document.querySelector(".back-to-top");
+window.addEventListener("scroll", () => {
+  backToTop.hidden = window.scrollY < 400;
+});
+backToTop.addEventListener("click", () => {
+  window.scrollTo({ top: 0, behavior: "smooth" });
+});

--- a/code-of-conduct/index.html
+++ b/code-of-conduct/index.html
@@ -8,11 +8,11 @@ hero_sub: Contributor Covenant 3.0 Code of Conduct
   <div class="container">
     <div class="prose">
 
-      <h2 id="our-pledge"><a href="#our-pledge" class="heading-anchor">#</a>Our Pledge</h2>
+      {% include heading.html title="Our Pledge" %}
       <p>We pledge to make our community welcoming, safe, and equitable for all.</p>
       <p>We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.</p>
 
-      <h2 id="encouraged-behaviors"><a href="#encouraged-behaviors" class="heading-anchor">#</a>Encouraged Behaviors</h2>
+      {% include heading.html title="Encouraged Behaviors" %}
       <p>While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.</p>
       <p>With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:</p>
       <ol>
@@ -25,7 +25,7 @@ hero_sub: Contributor Covenant 3.0 Code of Conduct
         <li>Behaving in other ways that promote and sustain the <strong>well-being of our community</strong>.</li>
       </ol>
 
-      <h2 id="restricted-behaviors"><a href="#restricted-behaviors" class="heading-anchor">#</a>Restricted Behaviors</h2>
+      {% include heading.html title="Restricted Behaviors" %}
       <p>We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.</p>
       <ol>
         <li><strong>Harassment.</strong> Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.</li>
@@ -45,12 +45,12 @@ hero_sub: Contributor Covenant 3.0 Code of Conduct
         <li><strong>Irresponsible communication.</strong> Failing to responsibly present content which includes, links or describes any other restricted behaviors.</li>
       </ol>
 
-      <h2 id="reporting-an-issue"><a href="#reporting-an-issue" class="heading-anchor">#</a>Reporting an Issue</h2>
+      {% include heading.html title="Reporting an Issue" %}
       <p>Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.</p>
       <p>When an incident does occur, it is important to report it promptly. To report a possible violation, email <a href="mailto:icalendar-coc@googlegroups.com">icalendar-coc@googlegroups.com</a>.</p>
       <p>Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.</p>
 
-      <h2 id="addressing-and-repairing-harm"><a href="#addressing-and-repairing-harm" class="heading-anchor">#</a>Addressing and Repairing Harm</h2>
+      {% include heading.html title="Addressing and Repairing Harm" %}
       <p>If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.</p>
 
       <h3>1. Warning</h3>
@@ -83,10 +83,10 @@ hero_sub: Contributor Covenant 3.0 Code of Conduct
 
       <p>This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.</p>
 
-      <h2 id="scope"><a href="#scope" class="heading-anchor">#</a>Scope</h2>
+      {% include heading.html title="Scope" %}
       <p>This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.</p>
 
-      <h2 id="attribution"><a href="#attribution" class="heading-anchor">#</a>Attribution</h2>
+      {% include heading.html title="Attribution" %}
       <p>This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at <a href="https://www.contributor-covenant.org/version/3/0/" target="_blank" rel="noopener">https://www.contributor-covenant.org/version/3/0/</a>.
       The only adaptation is the email address to report a possible violation.</p>
       <p>Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">CC BY-SA 4.0</a>.</p>

--- a/code-of-conduct/index.html
+++ b/code-of-conduct/index.html
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Code of Conduct
-eyebrow: Python Calendaring Ecosystem
 hero_sub: Contributor Covenant 3.0 Code of Conduct
 ---
 
@@ -9,11 +8,11 @@ hero_sub: Contributor Covenant 3.0 Code of Conduct
   <div class="container">
     <div class="prose">
 
-      <h2>Our Pledge</h2>
+      <h2 id="our-pledge"><a href="#our-pledge" class="heading-anchor">#</a>Our Pledge</h2>
       <p>We pledge to make our community welcoming, safe, and equitable for all.</p>
       <p>We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.</p>
 
-      <h2>Encouraged Behaviors</h2>
+      <h2 id="encouraged-behaviors"><a href="#encouraged-behaviors" class="heading-anchor">#</a>Encouraged Behaviors</h2>
       <p>While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.</p>
       <p>With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:</p>
       <ol>
@@ -26,7 +25,7 @@ hero_sub: Contributor Covenant 3.0 Code of Conduct
         <li>Behaving in other ways that promote and sustain the <strong>well-being of our community</strong>.</li>
       </ol>
 
-      <h2>Restricted Behaviors</h2>
+      <h2 id="restricted-behaviors"><a href="#restricted-behaviors" class="heading-anchor">#</a>Restricted Behaviors</h2>
       <p>We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.</p>
       <ol>
         <li><strong>Harassment.</strong> Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.</li>
@@ -46,12 +45,12 @@ hero_sub: Contributor Covenant 3.0 Code of Conduct
         <li><strong>Irresponsible communication.</strong> Failing to responsibly present content which includes, links or describes any other restricted behaviors.</li>
       </ol>
 
-      <h2>Reporting an Issue</h2>
+      <h2 id="reporting-an-issue"><a href="#reporting-an-issue" class="heading-anchor">#</a>Reporting an Issue</h2>
       <p>Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.</p>
       <p>When an incident does occur, it is important to report it promptly. To report a possible violation, email <a href="mailto:icalendar-coc@googlegroups.com">icalendar-coc@googlegroups.com</a>.</p>
       <p>Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.</p>
 
-      <h2>Addressing and Repairing Harm</h2>
+      <h2 id="addressing-and-repairing-harm"><a href="#addressing-and-repairing-harm" class="heading-anchor">#</a>Addressing and Repairing Harm</h2>
       <p>If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.</p>
 
       <h3>1. Warning</h3>
@@ -84,10 +83,10 @@ hero_sub: Contributor Covenant 3.0 Code of Conduct
 
       <p>This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.</p>
 
-      <h2>Scope</h2>
+      <h2 id="scope"><a href="#scope" class="heading-anchor">#</a>Scope</h2>
       <p>This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.</p>
 
-      <h2>Attribution</h2>
+      <h2 id="attribution"><a href="#attribution" class="heading-anchor">#</a>Attribution</h2>
       <p>This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at <a href="https://www.contributor-covenant.org/version/3/0/" target="_blank" rel="noopener">https://www.contributor-covenant.org/version/3/0/</a>.
       The only adaptation is the email address to report a possible violation.</p>
       <p>Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">CC BY-SA 4.0</a>.</p>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ layout: default
 
 <header>
   <div class="container">
-    <h1>Python Calendaring Ecosystem</h1>
+    <h1>{{ site.title }}</h1>
     <p class="hero-sub">
       The standards compliant, integrated Python calendar packages
     </p>
@@ -48,7 +48,7 @@ layout: default
         {% endfor %}
 
       </div>
-      <p>
+      <p class="see-all">
         <a href="/software">See all software →</a>
       </p>
     </div>

--- a/software/index.html
+++ b/software/index.html
@@ -1,14 +1,13 @@
 ---
 layout: page
 title: Software
-eyebrow: Python Calendaring Ecosystem
 hero_sub: Everything we maintain. Badges show stability status.
 ---
 
 {% for cat in site.data.categories %}
 <section class="section{% if cat.alt %} section-alt{% endif %}">
   <div class="container">
-    <h2 class="section-title" id="{{ cat.id }}"><a href="#{{ cat.id }}" class="section-anchor">{{ cat.title }} <span class="section-anchor-icon">🔗</span></a></h2>
+    <h2 class="section-title" id="{{ cat.id }}"><a href="#{{ cat.id }}" class="heading-anchor">#</a>{{ cat.title }}</h2>
     <p class="section-desc">{{ cat.description }}</p>
     <div class="package-grid">
       {% for pkg in site.data.packages %}

--- a/software/index.html
+++ b/software/index.html
@@ -7,7 +7,7 @@ hero_sub: Everything we maintain. Badges show stability status.
 {% for cat in site.data.categories %}
 <section class="section{% if cat.alt %} section-alt{% endif %}">
   <div class="container">
-    <h2 class="section-title" id="{{ cat.id }}"><a href="#{{ cat.id }}" class="heading-anchor">#</a>{{ cat.title }}</h2>
+    {% include heading.html title=cat.title id=cat.id class="section-title" %}
     <p class="section-desc">{{ cat.description }}</p>
     <div class="package-grid">
       {% for pkg in site.data.packages %}

--- a/team/index.html
+++ b/team/index.html
@@ -14,9 +14,9 @@ hero_sub: Small team, deep specifications, real servers. We welcome new contribu
         <div class="member-avatar">{{ member.avatar }}</div>
         <div class="member-info">
           <div class="member-header">
-            <h2 class="member-name">{{ member.name }}</h2>
-            <a href="https://github.com/{{ member.github }}" class="member-github" target="_blank" rel="noopener">@{{
-              member.github }}</a>
+            {% assign slug = member.name | slugify %}
+            <h2 class="member-name" id="{{ slug }}"><a href="#{{ slug }}" class="heading-anchor">#</a>{{ member.name }}</h2>
+            <a href="https://github.com/{{ member.github }}" class="member-github" target="_blank" rel="noopener">GitHub</a>
             {% if member.linkedin %}
             <a href="{{ member.linkedin }}" class="member-linkedin" target="_blank" rel="noopener">LinkedIn</a>
             {% endif %}

--- a/team/index.html
+++ b/team/index.html
@@ -14,8 +14,7 @@ hero_sub: Small team, deep specifications, real servers. We welcome new contribu
         <div class="member-avatar">{{ member.avatar }}</div>
         <div class="member-info">
           <div class="member-header">
-            {% assign slug = member.name | slugify %}
-            <h2 class="member-name" id="{{ slug }}"><a href="#{{ slug }}" class="heading-anchor">#</a>{{ member.name }}</h2>
+            {% include heading.html title=member.name class="member-name" %}
             <a href="https://github.com/{{ member.github }}" class="member-github" target="_blank" rel="noopener">GitHub</a>
             {% if member.linkedin %}
             <a href="{{ member.linkedin }}" class="member-linkedin" target="_blank" rel="noopener">LinkedIn</a>


### PR DESCRIPTION
Thanks @niccokunzmann, the shareable-section-anchor pattern from #23 wasn't something I'd considered before. Learnt something new from it.

Small UX and visual cleanups:

- `#` anchors on every `<h2>` across all pages
- Accent color changed from blue to teal so it sits better with the warm stone palette
- Link, selection, and focus colors moved off blue onto stone tones
- External links in prose get a small `↗`
- Package cards lift on hover
- Section seam borders removed on `/software/`
- Site name unified via `site.title` in `_config.yml`, officially "Python Calendaring Ecosystem"
- Team: `@username` became "GitHub" chip
- AI policy links to our own CoC
- Footer: Home link removed, the wordmark handles it